### PR TITLE
Allow setting the DEFAULT_URL to null

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -191,8 +191,7 @@ if (document.readyState === 'interactive' ||
   ///document.addEventListener('DOMContentLoaded', webViewerLoad, true); /// patched
   // === patch start ===
   PDFJS.webViewerLoad = function (src) {
-    if (src) DEFAULT_URL = src;
- 
+    DEFAULT_URL = src;
     webViewerLoad();
   }  
   // === patch end === 


### PR DESCRIPTION
So we can initialize the viewer, just without a pdf loaded in it: https://github.com/legalthings/pdf.js/issues/3
